### PR TITLE
Sync demo.html layout with wellio's html layout

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -1,125 +1,125 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8"/>
-		<meta http-equiv="X-UA-Compatible">
-		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<title>LAS Loading Script Test</title>
-		
-		<!-- BOOTSTRAP CSS GENERIC STYLESHEET & HELPERS   .  .  .-->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>LAS Loading Script Test</title>
 
-		<!-- USED TO HELP LOAD FILES -->
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" crossorigin="anonymous"></script>
+	<!-- BOOTSTRAP CSS GENERIC STYLESHEET & HELPERS   .  .  .-->
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
 
-    <!-- WHAT IS THIS FOR !? -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
-			
-		<!-- SCRIPT TO HELP BOOTSTRAP CSS -->
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+	<!-- USED TO HELP LOAD FILES -->
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" crossorigin="anonymous"></script>
 
-		<!-- SCRIPT FOR D3.JS A VISUALIZATION LIBRARY USED BY G3.JS -->
-		<script src="https://d3js.org/d3.v5.min.js"></script>
+	<!-- WHAT IS THIS FOR !? -->
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
 
-		<!-- SCRIPT FOR PRINTING JSON INTO A DOM ELEMENT SO IT LOOKS NICE ON A WEBPAGE -->
-		<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
+	<!-- SCRIPT TO HELP BOOTSTRAP CSS -->
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
 
-		<!-- SCRIPT FOR ADDING SPACES TO JSON SO IT LOOKS NICE ON A WEBPAGE -->
-		<script src="./js/vkbeautify.js"></script>
+	<!-- SCRIPT FOR D3.JS A VISUALIZATION LIBRARY USED BY G3.JS -->
+	<script src="https://d3js.org/d3.v5.min.js"></script>
 
-		<!-- MAIN WEBPAGE STYLESHEET -->
-		<link rel="stylesheet" href="./css/main.css"> 
+	<!-- SCRIPT FOR PRINTING JSON INTO A DOM ELEMENT SO IT LOOKS NICE ON A WEBPAGE -->
+	<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 
-		<!-- GEOLOGY DATA SPECIFIC VISUALIZATIONS BUILT ON TOP OF D3.JS -->
-		<!-- <script src="./js/g3.js"></script> -->
-		<script src="../dist/index.js"></script>
-		<!-- PLOTTING FUNCTIONS THAT CALL G3.JS FROM MAIN.JS -->
-		<script src="./js/call_plots.js"></script>
-		<!-- REST OF THE WEBPAGE FUNCTIONS -->
-		<script src="./js/main.js"></script>
-		<!-- LAS TO JSON JAVASCRIPT FUNCTIONS -->
-		<script src="./js/bundle.js"></script>
-		<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js.map"></script> -->
-	</head>
-	<body>
-		<div>
-			<h1>Barebones Demo Page for <a href="https://github.com/JustinGOSSES/wellio.js">Wellioviz.js</a></h1>
+	<!-- SCRIPT FOR ADDING SPACES TO JSON SO IT LOOKS NICE ON A WEBPAGE -->
+	<script src="./js/vkbeautify.js"></script>
+
+	<!-- MAIN WEBPAGE STYLESHEET -->
+	<link rel="stylesheet" href="./css/main.css">
+
+	<!-- GEOLOGY DATA SPECIFIC VISUALIZATIONS BUILT ON TOP OF D3.JS -->
+	<!-- <script src="./js/g3.js"></script> -->
+	<script src="../dist/index.js"></script>
+	<!-- PLOTTING FUNCTIONS THAT CALL G3.JS FROM MAIN.JS -->
+	<script src="./js/call_plots.js"></script>
+	<!-- REST OF THE WEBPAGE FUNCTIONS -->
+	<script src="./js/main.js"></script>
+	<!-- LAS TO JSON JAVASCRIPT FUNCTIONS -->
+	<script src="./js/bundle.js"></script>
+	<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js.map"></script> -->
+</head>
+<body>
+	<div>
+		<h1>Barebones Demo Page for <a href="https://github.com/JustinGOSSES/wellio.js">Wellioviz.js</a></h1>
+	</div>
+	<div class="well_step">
+		<h4>Upload local LAS files using a file loader & turn them into json using wellio.js.</h4>
+	</div>
+	<div class="well_step">
+		<p><b>First</b>: use either of these buttons to load a LAS files.</p>
+		<div class="well_pos_relative">
+			<a class='btn btn-primary' href='javascript:;'>
+				from your computer
+				<input type="file" id="files" multiple class='well_file_upload' name="file_source" size="40" onchange='$("#upload-file-info").html($(this).val());readInFilesFunction()'>
+			</a>
+
+			<span class='label label-info' id="upload-file-info"></span>
+			<button onclick="readInLASFromASSETS()" class='btn btn-primary'>from Assets folder of this webpage</button><span class='label label-info' id="upload-success"></span>
 		</div>
+		<output id="list"></output>
+	</div>
+
+	<div class="well_step">
+		<p><b>Second</b>: convert .las text into JSON. If you selected more than one las, the first will be used.</p>
+		<button onclick="convert_and_startHelpers()" class='btn btn-primary'>convert</button>
+		<p id="which_well"><i>no well selection</i></p>
+	</div>
+	<div class="well_step">
+		<h4>Display Results as original text (A), converted JSON (B), or visual curves using Wellio.js (C)</h4>
+	</div>
+	<div class="well_step">
+		<p><b>A.</b> Display of .las files as text</p>
+		<button onclick="displayFileFunction() " class='btn btn-secondary'>display text</button>
+		<button onclick="removeTextLAS()" class='btn btn-secondary'>remove text</button>
+	</div>
+
+	<div class="well_step_left">
+		<p><b>B.</b>Buttons to draw each curve in the select well will appear below after the <b>CONVERT</b> step</p>
+
+		<div id="curveButtons_holder"></div>
+		<p>Remove all curves</p><button onclick="remove_DOM_children()" class='btn btn-secondary'>remove</button>
+	</div>
+
+	<div style="float:left;width:100%" class="step">
+		<p><b>C.</b> Print well in wellio.js JSON format</p>
+		<button onclick="print_well()" class='btn btn-secondary'>print json</button>
+		<button onclick="remove_DOM_children('well_json_prettyprint')" class='btn btn-secondary'>remove json</button>
+	</div>
+
+	</br>
+	<!-- <div>
+		<p>Remove all curves</p>
+		<button onclick="remove_DOM_children()">remove</button>
+	</div> -->
+	<div id="fileContents"></div>
+	<div class="plot_holder">
+		<div id="log_plot_div" class="log_plot_div box"></div>
+		<div class="log_plot_div2 box"></div>
+	</div>
+	</br>
+<div style="float:left"></div>
+	</br>
+	<!-- <div style="float:left;width:100%">
+		<span>
+			<button onclick="print_well()" class='btn btn-secondary'>Print well in wellio.js JSON format</button>
+		<button onclick="remove_DOM_children('well_json_prettyprint')" class='btn btn-secondary'>remove json</button>
+		</span>
+	</div> -->
+	</br>
+	<div class="well_left_full_width">
+		<pre id="well_json_prettyprint" class="prettyprint">
+		</pre>
+	</div>
+	</br>
+	<div class="well_left">
 		<div class="well_step">
-			<h4>Upload local LAS files using a file loader & turn them into json using wellio.js.</h4>
+			<h3>Download well as JSON file</h3>
+			<button id="download_button" onclick="download_test()" class='btn btn-secondary'>download</button>
 		</div>
-		<div class="well_step">
-			<p><b>First</b>: use either of these buttons to load a LAS files.</p>
-			<div class="well_pos_relative">
-				<a class='btn btn-primary' href='javascript:;'>
-					from your computer
-					<input type="file" id="files" multiple class='well_file_upload' name="file_source" size="40" onchange='$("#upload-file-info").html($(this).val());readInFilesFunction()'>
-				</a>
-	
-				<span class='label label-info' id="upload-file-info"></span>
-				<button onclick="readInLASFromASSETS()" class='btn btn-primary'>from Assets folder of this webpage</button><span class='label label-info' id="upload-success"></span>
-			</div>
-			<output id="list"></output>
-		</div>
-	
-		<div class="well_step">
-			<p><b>Second</b>: convert .las text into JSON. If you selected more than one las, the first will be used.</p>
-			<button onclick="convert_and_startHelpers()" class='btn btn-primary'>convert</button>
-			<p id="which_well"><i>no well selection</i></p>
-		</div>
-		<div class="well_step">
-			<h4>Display Results as original text (A), converted JSON (B), or visual curves using Wellio.js (C)</h4>
-		</div>
-		<div class="well_step">
-			<p><b>A.</b> Display of .las files as text</p>
-			<button onclick="displayFileFunction() " class='btn btn-secondary'>display text</button>
-			<button onclick="removeTextLAS()" class='btn btn-secondary'>remove text</button>
-		</div>
-	
-		<div class="well_step_left">
-			<p><b>B.</b>Buttons to draw each curve in the select well will appear below after the <b>CONVERT</b> step</p>
-	
-			<div id="curveButtons_holder"></div>
-			<p>Remove all curves</p><button onclick="remove_DOM_children()" class='btn btn-secondary'>remove</button>
-		</div>
-	
-		<div style="float:left;width:100%" class="step">
-			<p><b>C.</b> Print well in wellio.js JSON format</p>
-			<button onclick="print_well()" class='btn btn-secondary'>print json</button>
-			<button onclick="remove_DOM_children('well_json_prettyprint')" class='btn btn-secondary'>remove json</button>
-		</div>
-	
-		</br>
-		<!-- <div>
-			<p>Remove all curves</p>
-			<button onclick="remove_DOM_children()">remove</button>
-		</div> -->
-		<div id="fileContents"></div>
-		<div class="plot_holder">
-			<div id="log_plot_div" class="log_plot_div box"></div>
-			<div class="log_plot_div2 box"></div>
-		</div>
-		</br>
-	<div style="float:left"></div>
-		</br>
-		<!-- <div style="float:left;width:100%">
-			<span>
-				<button onclick="print_well()" class='btn btn-secondary'>Print well in wellio.js JSON format</button>
-			<button onclick="remove_DOM_children('well_json_prettyprint')" class='btn btn-secondary'>remove json</button>
-			</span>
-		</div> -->
-		</br>
-		<div class="well_left_full_width">
-			<pre id="well_json_prettyprint" class="prettyprint">
-			</pre>
-		</div>
-		</br>
-		<div class="well_left">
-			<div class="well_step">
-				<h3>Download well as JSON file</h3>
-				<button id="download_button" onclick="download_test()" class='btn btn-secondary'>download</button>
-			</div>
-		</div>
-		</br>
-	</body>
+	</div>
+	</br>
+</body>
 </html>


### PR DESCRIPTION
Sync demo.html layout with wellio's html layout

## Description
This is a minor change that aligns all the tabs and spaces between wellio.js/index.html and wellioviz/docs/demo.html.  This makes it very easy to see the functional differences between them.  

## Related Issue
N/A

## Motivation and Context
This makes it very easy to see the functional differences between wellio.js/index.html and wellioviz/docs/demo.html and keep them properly aligned.

## Types of changes
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.

Note: Test run:
- Load a las file
- convert the las file
- display the text
- print (display) the son

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
