### PR TITLE
Iterate demo page header style

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -1,3 +1,4 @@
+
 .plot_holder{
 	margin-top: 10px;
 	float:left;
@@ -13,10 +14,6 @@
 	margin: 10px 5px 0 0;
 }
 
-body{
-	margin-left:3%;
-	padding-bottom: 50px;
-}
 
 [hidden] {
   display: none !important;

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -42,12 +42,12 @@
 	<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js.map"></script> -->
 </head>
 <body>
-	<div>
-		<h1>Barebones Demo Page for <a href="https://github.com/JustinGOSSES/wellio.js">Wellioviz.js</a></h1>
+	<div class="jumbotron text-center">
+		<h1><a href="https://github.com/JustinGOSSES/wellioviz">Wellioviz</a></h1>
+		<h2>Demo Page</h2>
+		<h5>A JavaScript library for visualizing well logs.</h5>
 	</div>
-	<div class="well_step">
-		<h4>Upload local LAS files using a file loader & turn them into json using wellio.js.</h4>
-	</div>
+	<div class="container">
 	<div class="well_step">
 		<p><b>First</b>: use either of these buttons to load a LAS files.</p>
 		<div class="well_pos_relative">
@@ -119,6 +119,7 @@
 			<h3>Download well as JSON file</h3>
 			<button id="download_button" onclick="download_test()" class='btn btn-secondary'>download</button>
 		</div>
+	</div>
 	</div>
 	</br>
 </body>


### PR DESCRIPTION
Iterate demo page header style

## Description
This pull-request improves the style of the Headers on the demo.html.  It puts the main title and header information in a Bootstrap 'jumbotron'.  The spacing could be improved in a follow-up iteration.   Additionally the boarder spacing is changed to use Bootstraps 'container' spacing.  


## Related Issue
https://github.com/JustinGOSSES/wellio.js/issues/52
Duplication of demo page between wellio & wellioviz?

## Motivation and Context
This change improves the audience viewing experience of the demo.html.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Note: Test run:
- Load a las file
- Convert the las file
   UWI displays
   Curve Headers display
   Clicking on a Curve Header attempts to display visually, but fails (same behavior as before)

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
