### PR TITLE
Add browserify as a dependency and a script to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "unpkg": "dist/index.js",
   "scripts": {
-    "test": "dist/test/test.js"
+    "test": "dist/test/test.js",
+    "make_bundle": "cd docs/js && browserify call_plots.js main.js get_wellio.js vkbeautify.js -o bundle.js"
   },
   "files": [
     "dist/test/test.js",
@@ -45,6 +46,7 @@
     "wellio": "^0.1.7"
   },
   "devDependencies": {
+    "browserify": "^16.5.1",
     "eslint-config-google": "^0.9.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.9.0",


### PR DESCRIPTION
## Description
Now that browserify is needed to create bundle.js, adding it to package.json

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Commit: https://github.com/JustinGOSSES/wellioviz/commit/af4d79c5d740132175a8e918dec69cae93aab51a  adds instructions for using browserify to generate bundle.js.


## Motivation and Context
This change add browserify to package.json so that it is available as needed in development and deployment.  Additionally, this change adds the browserify command to package.json[scripts] so that one can run: ```npm run make_bundle``` to generate docs/js/bundle.js

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Tests:
- npm install
  - expected output: browserify installed
- npm run make_bundle
  - expected output: new docs/js/bundle.js is created.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
