### PR TITLE
  Add menu buttons for all major LAS UI components

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -33,11 +33,12 @@
 
 
 div.well_step {
-	margin-top: 40px;
+	margin-top: 1em;
 }
 
 div.well_step_left {
-	margin-top: 40px;
+	margin-top: 1em;
+	margin-bottom: 1em;
 	float: left;
 	width: 100%;
 }

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -85,6 +85,7 @@
 		<p><b>A.</b> Display of .las files as text</p>
 		<button onclick="displayFileFunction() " class='btn btn-secondary'>display text</button>
 		<button onclick="removeTextLAS()" class='btn btn-secondary'>remove text</button>
+		<div id="fileContents"></div>
 	</div>
 	</div>
 
@@ -97,7 +98,6 @@
 			<p>Remove all curves</p>
 			<button onclick="remove_DOM_children()">remove</button>
 		</div> -->
-		<div id="fileContents"></div>
 		<div class="plot_holder">
 			<div id="log_plot_div" class="log_plot_div box"></div>
 			<div class="log_plot_div2 box"></div>

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -48,6 +48,12 @@
 		<h5>A JavaScript library for visualizing well logs.</h5>
 	</div>
 	<div class="container">
+		<button class="btn btn-primary btn-sm" data-toggle="collapse" data-target="#wellupload">Upload and convert LAS file</button>
+		<button class="btn btn-primary btn-sm" data-toggle="collapse" data-target="#welldisplaycurves">Display Curves</button>
+		<button class="btn btn-primary btn-sm" data-toggle="collapse" data-target="#welldisplaytext">Display LAS file</button>
+		<button class="btn btn-primary btn-sm" data-toggle="collapse" data-target="#welldisplayjson">Display JSON</button>
+		<button class="btn btn-primary btn-sm" data-toggle="collapse" data-target="#welldownloadjson">Download JSON</button>
+	<div id="wellupload" class="collapse">
 	<div class="well_step">
 		<p><b>First</b>: use either of these buttons to load a LAS files.</p>
 		<div class="well_pos_relative">
@@ -56,8 +62,10 @@
 				<input type="file" id="files" multiple class='well_file_upload' name="file_source" size="40" onchange='$("#upload-file-info").html($(this).val());readInFilesFunction()'>
 			</a>
 
+			<button onclick="readInLASFromASSETS()" class='btn btn-primary'>from Assets folder of this webpage</button>
+			<span class='label label-info' id="upload-success"></span>
+			</br>
 			<span class='label label-info' id="upload-file-info"></span>
-			<button onclick="readInLASFromASSETS()" class='btn btn-primary'>from Assets folder of this webpage</button><span class='label label-info' id="upload-success"></span>
 		</div>
 		<output id="list"></output>
 	</div>
@@ -67,6 +75,9 @@
 		<button onclick="convert_and_startHelpers()" class='btn btn-primary'>convert</button>
 		<p id="which_well"><i>no well selection</i></p>
 	</div>
+	</div>
+
+	<div id="welldisplaytext" class="collapse">
 	<div class="well_step">
 		<h4>Display Results as original text (A), converted JSON (B), or visual curves using Wellio.js (C)</h4>
 	</div>
@@ -75,37 +86,37 @@
 		<button onclick="displayFileFunction() " class='btn btn-secondary'>display text</button>
 		<button onclick="removeTextLAS()" class='btn btn-secondary'>remove text</button>
 	</div>
+	</div>
 
-	<div class="well_step_left">
+	<div id="welldisplaycurves" class="collapse well_step_left">
 		<p><b>B.</b>Buttons to draw each curve in the select well will appear below after the <b>CONVERT</b> step</p>
 
 		<div id="curveButtons_holder"></div>
 		<p>Remove all curves</p><button onclick="remove_DOM_children()" class='btn btn-secondary'>remove</button>
+		<!-- <div>
+			<p>Remove all curves</p>
+			<button onclick="remove_DOM_children()">remove</button>
+		</div> -->
+		<div id="fileContents"></div>
+		<div class="plot_holder">
+			<div id="log_plot_div" class="log_plot_div box"></div>
+			<div class="log_plot_div2 box"></div>
+		</div>
+		</br>
 	</div>
 
-	<div style="float:left;width:100%" class="step">
+	<div id="welldisplayjson" class="collapse well_step_left">
 		<p><b>C.</b> Print well in wellio.js JSON format</p>
 		<button onclick="print_well()" class='btn btn-secondary'>print json</button>
 		<button onclick="remove_DOM_children('well_json_prettyprint')" class='btn btn-secondary'>remove json</button>
-	</div>
 
-	</br>
-	<!-- <div>
-		<p>Remove all curves</p>
-		<button onclick="remove_DOM_children()">remove</button>
-	</div> -->
-	<div id="fileContents"></div>
-	<div class="plot_holder">
-		<div id="log_plot_div" class="log_plot_div box"></div>
-		<div class="log_plot_div2 box"></div>
-	</div>
 	</br>
 <div style="float:left"></div>
 	</br>
 	<!-- <div style="float:left;width:100%">
 		<span>
 			<button onclick="print_well()" class='btn btn-secondary'>Print well in wellio.js JSON format</button>
-		<button onclick="remove_DOM_children('well_json_prettyprint')" class='btn btn-secondary'>remove json</button>
+			<button onclick="remove_DOM_children('well_json_prettyprint')" class='btn btn-secondary'>remove json</button>
 		</span>
 	</div> -->
 	</br>
@@ -113,8 +124,10 @@
 		<pre id="well_json_prettyprint" class="prettyprint">
 		</pre>
 	</div>
+	</div>
 	</br>
-	<div class="well_left">
+
+	<div id="welldownloadjson" class="collapse well_step_left">
 		<div class="well_step">
 			<h3>Download well as JSON file</h3>
 			<button id="download_button" onclick="download_test()" class='btn btn-secondary'>download</button>


### PR DESCRIPTION

## Description
This pull request changes the demo display to have a set of menu buttons just under the header. The individual user interface components are only visible when the user has selected that item from the menu. This enables the user to focus only on the current activity. The buttons are arranged in general task order.

## Related Issue
This change is a minor subset of #37 (sync demo with index.js)

## Motivation and Context
This change organizes the Demo's user interface.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed. ( I ran the demo.html page, loaded some las files, displayed las text,displayed some curves, and removed curves. Also visually checked that the page continues to display significantly the same.)


Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
