### PR TITLE
Update bootstrap to 4.5.0, jquery to 3.5.1

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -7,16 +7,19 @@
 	<title>LAS Loading Script Test</title>
 
 	<!-- BOOTSTRAP CSS GENERIC STYLESHEET & HELPERS   .  .  .-->
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+	<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
 
 	<!-- USED TO HELP LOAD FILES -->
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" crossorigin="anonymous"></script>
+	<!-- https://getbootstrap.com/docs/4.5/getting-started/introduction/ -->
+	<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
 
 	<!-- WHAT IS THIS FOR !? -->
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
 
 	<!-- SCRIPT TO HELP BOOTSTRAP CSS -->
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+	<!-- https://getbootstrap.com/docs/4.5/getting-started/introduction/ -->
+	<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+	<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
 
 	<!-- SCRIPT FOR D3.JS A VISUALIZATION LIBRARY USED BY G3.JS -->
 	<script src="https://d3js.org/d3.v5.min.js"></script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull-request updates docs/demo.html to use Bootstrap 4.5.0 and Jquery slim 3.5.1.
Previously demo.html was using an alpha level version of bootstrap (4.0.0-alpha.6).  

Demo.html was using the cdn install of Bootstrap so this update continues to use the recommended cdn. The install instructions are found here: 
https://getbootstrap.com/docs/4.5/getting-started/introduction/


## Related Issue
Resolves #105 Update demo.html's bootstrap4 to the current release 4.5.0.

## Motivation and Context
Move from an alpha Bootstrap version to a production level version.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Test results:
```bash
npm test
PASS dist/test/log_templates.test.js
  ✓ default log curve template name is a property (5 ms)
  ✓ test define data function (1 ms)
  ✓ test define curve and data function

PASS dist/test/track_template.test.js
  ✓ default track name is a property (2 ms)
  ✓ add curve works (1 ms)

PASS dist/test/well_section_template.test.js
  ✓ default well section template is a property (2 ms)

PASS dist/test/well_log_template.test.js
  ✓ default well log name is a property (3 ms)

PASS dist/test/curve_fill_template.test.js
  ✓ default fill curve template curve_name is a property (2 ms)

PASS dist/test/triple_combo.test.js
  ✓ default track name is a property (3 ms)
  ✓ load a log into triple combo template (12 ms)

Test Suites: 6 passed, 6 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        3.887 s
Ran all test suites.
```
